### PR TITLE
ISSUE-110  Fix default thumbnail size and fix used pictures

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,8 +1,11 @@
-# 1.5.8
+# 1.5.9
+* Beheben der vorgegebenen Thumbnail-Größen [#110](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/pull/110/files)
 * Newest blog items [#108](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/pull/108/files)
+* Fix Block is overwritten instead of added [#116](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/pull/116/files)
+
+# 1.5.8
 * Fix error when run bin/console dal:validation [#97](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/pull/97/files)
 * Fix SERP Information and Preview Picture for shopware 6.4.9.0 or later [#100](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/pull/100/files)
-* Fix Block is overwritten instead of added [#116](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/pull/116/files)
 
 # 1.5.7
 * Fixed compiled administration file

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,8 +1,11 @@
-# 1.5.8
+# 1.5.9
+* Fix default thumbnail size [#110](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/pull/110/files)
 * Newest blog items [#108](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/pull/108/files)
+* Fix Block is overwritten instead of added [#116](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/pull/116/files)
+
+# 1.5.8
 * Fix error when run bin/console dal:validation [#97](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/pull/97/files)
 * Fix SERP Information and Preview Picture for shopware 6.4.9.0 or later [#100](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/pull/100/files)
-* Fix Block is overwritten instead of added [#116](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/pull/116/files)
 
 # 1.5.7
 * Fixed compiled administration file

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "sas/blog-module",
     "description": "Blog Module",
-    "version": "1.5.8",
+    "version": "1.5.9",
     "type": "shopware-platform-plugin",
     "keywords": ["blog", "news"],
     "license":"MIT",

--- a/src/Resources/views/storefront/component/blog/card/box.html.twig
+++ b/src/Resources/views/storefront/component/blog/card/box.html.twig
@@ -15,7 +15,10 @@
                             media: article.media,
                             sizes: {
                                 'xs': '330px',
-                                'lg': '650px'
+                                'sm': '650px',
+                                'md': '650px',
+                                'lg': '650px',
+                                'xl': '900px',
                             }
                         } %}
                     {% else %}

--- a/src/Resources/views/storefront/element/cms-element-blog-detail.html.twig
+++ b/src/Resources/views/storefront/element/cms-element-blog-detail.html.twig
@@ -27,13 +27,13 @@
                             } %}
 
                             {% sw_thumbnails 'blog-image-teaser' with {
-                                    media: element.data.media,
-                                    sizes: {
-                                    'xs': '501px',
-                                    'sm': '315px',
-                                    'md': '427px',
-                                    'lg': '333px',
-                                    'xl': '284px'
+                                media: element.data.media,
+                                sizes: {
+                                    'xs': '650px',
+                                    'sm': '650px',
+                                    'md': '650px',
+                                    'lg': '900px',
+                                    'xl': '1280px',
                                 }
                             } %}
                         {% endif %}

--- a/src/SasBlogModule.php
+++ b/src/SasBlogModule.php
@@ -110,10 +110,24 @@ class SasBlogModule extends Plugin
                     'useParentConfiguration' => false,
                     'configuration' => [
                         'createThumbnails' => true,
+                        'keepAspectRatio' => true,
+                        'thumbnailQuality' => 90,
                         'mediaThumbnailSizes' => [
                             [
+                                'width' => 330,
+                                'height' => 185,
+                            ],
+                            [
                                 'width' => 650,
-                                'height' => 330,
+                                'height' => 365,
+                            ],
+                            [
+                                'width' => 900,
+                                'height' => 506,
+                            ],
+                            [
+                                'width' => 1280,
+                                'height' => 720,
                             ],
                         ],
                     ],


### PR DESCRIPTION
What I did:

* Fixed default image size (kept aspect ratio, increased image quality, added more sizes).
* I guess there were 2 sizes intended: 330px and 650px. I kept them and also added 900 and 1280px. Each aspect ratio is 16:9 (330px in width means 185px in height).

Fixes #110