### PR TITLE
Update BlogListingFilterBuildEvent.php

### DIFF
--- a/src/Content/Blog/BlogListingFilterBuildEvent.php
+++ b/src/Content/Blog/BlogListingFilterBuildEvent.php
@@ -3,6 +3,7 @@
 namespace Sas\BlogModule\Content\Blog;
 
 use Sas\BlogModule\Content\Blog\Events\BlogMainFilterEvent;
+use Shopware\Core\Framework\Event\Annotation\Event;
 
 class BlogListingFilterBuildEvent
 {


### PR DESCRIPTION
added use to avoid error 

Undefined constant Sas\BlogModule\Content\Blog\BlogListingFilterBuildEvent::BLOG_MAIN_FILTER_EVENT