### PR TITLE
fix missing _entity default for route store-api.sas.blog.load

### DIFF
--- a/src/Controller/StoreApi/BlogController.php
+++ b/src/Controller/StoreApi/BlogController.php
@@ -7,7 +7,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\Framework\Routing\Annotation\Entity;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -34,7 +33,6 @@ class BlogController extends AbstractBlogController
     }
 
     /**
-     * @Entity("sas_blog_entries")
      * @OA\Get(
      *      path="/store-api/blog",
      *      summary="This route can be used to load the sas_blog_entries by specific filters",
@@ -63,7 +61,7 @@ class BlogController extends AbstractBlogController
      *          )
      *     )
      * )
-     * @Route("/store-api/blog", name="store-api.sas.blog.load", methods={"GET","POST"})
+     * @Route("/store-api/blog", name="store-api.sas.blog.load", methods={"GET","POST"}, defaults={"_entity"="sas_blog_entries"})
      */
     public function load(Request $request, Criteria $criteria, SalesChannelContext $context): BlogControllerResponse
     {


### PR DESCRIPTION
This fixes the exception "Missing _entity route default for route: store-api.sas.blog.load" which we've found with Shopware 6.5.5.2 and pwa storefront.