### PR TITLE
Fix display boxed modus of blog

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 2.0.9
+- Fehler behoben, das Boxed Darstellung geprüft wird vom Blog und nicht von der Hauptseite
+
 # 2.0.8
 - Gelöst für das Problem [#206](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/issues/206)
 

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,3 +1,6 @@
+# 2.0.9
+- Error fixed, the Boxed display is checked for the blog and not the main page
+
 # 2.0.8
 - Fixed for issue [#206](https://github.com/ChristopherDosin/Shopware-6-Blog-Plugin/issues/206)
 - 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "sas/blog-module",
     "description": "Blog Module",
-    "version": "2.0.8",
+    "version": "2.0.9",
     "type": "shopware-platform-plugin",
     "keywords": ["blog", "news"],
     "license":"MIT",

--- a/src/Resources/views/storefront/block/cms-block-blog-detail.html.twig
+++ b/src/Resources/views/storefront/block/cms-block-blog-detail.html.twig
@@ -1,7 +1,7 @@
 {% block block_sas_blog_detail %}
     {% set element = block.slots.getSlot('blogDetail') %}
 
-    <div class="{% if section and section.sizingMode === 'boxed' %}col-md-8 offset-md-2{% endif %} abc" data-cms-element-id="{{ element.id }}">
+    <div class="{% if section and section.section and section.section.sizingMode === 'boxed' %}col-md-8 offset-md-2{% endif %} abc" data-cms-element-id="{{ element.id }}">
         {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
     </div>
 


### PR DESCRIPTION
As far of my understanding the blog has a nested cms-page, because it uses the same CMS Editor.
Therefore if we check section it's checking the main page section, rather than the inner element.

if this doesn't apply disregard this pull request :)